### PR TITLE
#150802284 Implement single baseUrl for recipes search

### DIFF
--- a/server/controllers/recipe.js
+++ b/server/controllers/recipe.js
@@ -97,7 +97,10 @@ const recipeController = {
       })
       .catch(error => res.status(400).json(error));
   },
-  getRecipes(req, res) {
+  getRecipes(req, res, next) {
+    if (req.query.ingredients ||
+      req.query.sort ||
+      req.query.category) return next();
     return Recipe
       .all({
         include: [{
@@ -130,7 +133,8 @@ const recipeController = {
       })
       .catch(error => res.status(400).json(error));
   },
-  getTopRecipes(req, res) {
+  getTopRecipes(req, res, next) {
+    if (req.query.ingredients || req.query.category) return next();
     const sort = req.query.sort,
       order = req.query.order;
     return Recipe
@@ -161,7 +165,8 @@ const recipeController = {
       })
       .catch(error => res.status(400).send(error));
   },
-  searchRecipesByIngredients(req, res) {
+  searchRecipesByIngredients(req, res, next) {
+    if (req.query.category) return next();
     const ingredients = req.query.ingredients;
     return Recipe
       .all({

--- a/server/routes/recipe.js
+++ b/server/routes/recipe.js
@@ -8,10 +8,7 @@ import userValidation from '../middlewares/userValidation';
 const router = express.Router();
 
 router.post('/api/v1/recipes', auth, userValidation.validUser, recipeValidation.basicValidation, recipeController.create);
-router.get('/api/v1/recipes', auth, userValidation.validUser, recipeController.getRecipes);
-router.get('/api/v1/recipes/ingredients', auth, userValidation.validUser, recipeController.searchRecipesByIngredients);
-router.get('/api/v1/recipes/category', auth, userValidation.validUser, recipeController.searchRecipesByCategory);
-router.get('/api/v1/recipes/sort', auth, userValidation.validUser, recipeController.getTopRecipes);
+router.get('/api/v1/recipes', auth, userValidation.validUser, recipeController.getRecipes, recipeController.getTopRecipes, recipeController.searchRecipesByIngredients, recipeController.searchRecipesByCategory);
 router.get('/api/v1/recipes/user', auth, userValidation.validUser, recipeController.getUserRecipes);
 router.put('/api/v1/recipes/:recipeId', auth, userValidation.validUser, recipeValidation.recipeExists, recipeController.update);
 router.get('/api/v1/recipes/:recipeId', auth, validate, userValidation.validUser, recipeValidation.recipeExists, recipeController.viewRecipe);

--- a/server/test/xrecipeTest.js
+++ b/server/test/xrecipeTest.js
@@ -145,7 +145,7 @@ describe('Keep records of recipe views', () => {
 describe('View top recipes', () => {
   it('show recipes with highest upvote first', (done) => {
     server
-      .get('/api/v1/recipes/sort')
+      .get('/api/v1/recipes')
       .query({ sort: 'upvote', order: 'desc' })
       .set('Connection', 'keep alive')
       .set('Accept', 'application/json')

--- a/server/test/yfavoriteTest.js
+++ b/server/test/yfavoriteTest.js
@@ -99,7 +99,7 @@ describe('Favorite a recipe', () => {
 describe('Search recipes', () => {
   it('shows recipes with search by ingredients', (done) => {
     server
-      .get('/api/v1/recipes/ingredients')
+      .get('/api/v1/recipes')
       .query({ ingredients: 'cabbage' })
       .set('Connection', 'keep alive')
       .set('Accept', 'application/json')
@@ -114,7 +114,7 @@ describe('Search recipes', () => {
   });
   it('shows recipes with search by category', (done) => {
     server
-      .get('/api/v1/recipes/category')
+      .get('/api/v1/recipes')
       .query({ category: 'smoothies' })
       .set('Connection', 'keep alive')
       .set('Accept', 'application/json')


### PR DESCRIPTION
#### What does this PR do?
Have a single base path for getting recipes in the application including when querying
#### Description of Task to be completed?
Make `GET api/v1/recipes` be the base path for querying recipes by category, ingredients or sort
#### How should this be manually tested?
After cloning the repo, cd into it, run `npm install` and then `npm start`
Test the API route above using postman
* Obtain token for authentication from login endpoint `POST api/v1/users/signin`
* Get recipes by highest upvotes by using params `sort=upvote&order=desc`
#### What are the relevant pivotal tracker stories?
#150802284