### PR TITLE
#150878453 Allow user remove vote decision

### DIFF
--- a/server/controllers/vote.js
+++ b/server/controllers/vote.js
@@ -9,7 +9,7 @@ const voteController = {
       .findOrCreate({ where: {
         userId: req.decoded.user.id,
         recipeId: req.params.recipeId },
-        defaults: { option: true }
+      defaults: { option: true }
       })
       .spread((voter, created) => {
         if (created) {
@@ -41,11 +41,21 @@ const voteController = {
                 }));
               });
             });
+        } else if (!created && voter.option === true) {
+          voter.destroy();
+          return Recipe
+            .findOne({ where: { id: req.params.recipeId } })
+            .then((recipe) => {
+              recipe.decrement('upvote').then(() => {
+                recipe.reload();
+              }).then(() => res.status(200).send({
+                status: 'success',
+                message: 'Your vote has been removed',
+                upvote: recipe.upvote,
+                downvote: recipe.downvote
+              }));
+            });
         }
-        return res.status(400).send({
-          status: 'fail',
-          message: 'User has already upvoted'
-        });
       })
       .catch(error => res.status(400).send(error));
   },
@@ -54,7 +64,7 @@ const voteController = {
       .findOrCreate({ where: {
         userId: req.decoded.user.id,
         recipeId: req.params.recipeId },
-        defaults: { option: false }
+      defaults: { option: false }
       })
       .spread((voter, created) => {
         if (created) {
@@ -86,14 +96,24 @@ const voteController = {
                 }));
               });
             });
+        } else if (!created && voter.option === false) {
+          voter.destroy();
+          return Recipe
+            .findOne({ where: { id: req.params.recipeId } })
+            .then((recipe) => {
+              recipe.decrement('downvote').then(() => {
+                recipe.reload();
+              }).then(() => res.status(200).send({
+                status: 'success',
+                message: 'Your vote has been removed',
+                upvote: recipe.upvote,
+                downvote: recipe.downvote
+              }));
+            });
         }
-        return res.status(400).send({
-          status: 'fail',
-          message: 'User has already downvoted'
-        });
       })
       .catch(error => res.status(400).send(error));
-  },
+  }
 };
 
 export default voteController;


### PR DESCRIPTION
#### What does this PR do?
Fixes bug in logic such that a user that has upvoted or downvoted can remove his or her voting decision
#### Description of Task to be completed?
Upvoting and Downvoting decisions should be removable by user so that upvote count or downvote retains value before vote was done
#### How should this be manually tested?
After cloning the repo, cd into it, run  `npm install` and then `npm start`
* Test the API route above using postman
* Obtain token authorization from `GET  ap1/v1/users/signin`
* Set token in header with key x-access- token
#### What are the relevant pivotal tracker stories?
#150878453
![image](https://user-images.githubusercontent.com/26303683/30175383-42a3f678-93f6-11e7-9036-de69c9ac08ce.png)
