### PR TITLE
#150878383 Implement distinct category search for User Favorite and Global

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -35,12 +35,10 @@ const userController = {
             return user
               .update({
                 password: req.body.password
-              }).then(() => {
-                return res.status(200).send({
-                  status: 'success',
-                  message: 'Password changed successfully'
-                });
-              });
+              }).then(() => res.status(200).send({
+                status: 'success',
+                message: 'Password changed successfully'
+              }));
           }
         }
         return res.status(503).send({

--- a/server/controllers/vote.js
+++ b/server/controllers/vote.js
@@ -6,10 +6,11 @@ const Vote = db.Vote;
 const voteController = {
   upvote(req, res) {
     return Vote
-      .findOrCreate({ where: {
-        userId: req.decoded.user.id,
-        recipeId: req.params.recipeId },
-      defaults: { option: true }
+      .findOrCreate({
+        where: {
+          userId: req.decoded.user.id,
+          recipeId: req.params.recipeId },
+        defaults: { option: true }
       })
       .spread((voter, created) => {
         if (created) {
@@ -61,10 +62,11 @@ const voteController = {
   },
   downvote(req, res) {
     return Vote
-      .findOrCreate({ where: {
-        userId: req.decoded.user.id,
-        recipeId: req.params.recipeId },
-      defaults: { option: false }
+      .findOrCreate({
+        where: {
+          userId: req.decoded.user.id,
+          recipeId: req.params.recipeId },
+        defaults: { option: false }
       })
       .spread((voter, created) => {
         if (created) {

--- a/server/routes/recipe.js
+++ b/server/routes/recipe.js
@@ -9,6 +9,7 @@ const router = express.Router();
 
 router.post('/api/v1/recipes', auth, userValidation.validUser, recipeValidation.basicValidation, recipeController.create);
 router.get('/api/v1/recipes', auth, userValidation.validUser, recipeController.getRecipes, recipeController.getTopRecipes, recipeController.searchRecipesByIngredients, recipeController.searchRecipesByCategory);
+router.get('/api/v1/users/recipes', auth, userValidation.validUser, recipeController.searchUserFavsByCategory);
 router.get('/api/v1/recipes/user', auth, userValidation.validUser, recipeController.getUserRecipes);
 router.put('/api/v1/recipes/:recipeId', auth, userValidation.validUser, recipeValidation.recipeExists, recipeController.update);
 router.get('/api/v1/recipes/:recipeId', auth, validate, userValidation.validUser, recipeValidation.recipeExists, recipeController.viewRecipe);

--- a/server/test/yfavoriteTest.js
+++ b/server/test/yfavoriteTest.js
@@ -112,7 +112,7 @@ describe('Search recipes', () => {
         done();
       });
   });
-  it('shows recipes with search by category', (done) => {
+  it('shows no recipes matches search if not found', (done) => {
     server
       .get('/api/v1/recipes')
       .query({ category: 'smoothies' })
@@ -122,7 +122,7 @@ describe('Search recipes', () => {
       .set('Content-Type', 'application/json')
       .end((err, res) => {
         expect(res.statusCode).to.equal(200);
-        expect(res.body[0].Recipe.recipeName).to.equal('Coleslaw Salad');
+        expect(res.body.message).to.equal('No recipe matches your search');
         if (err) return done(err);
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
Allows search by category to be performed for categories a user has declared for recipes added to his/her favorite recipe list. And also a user can search for recipes by category in the application with a different category listing.
Refactor the search logic used
#### Description of Task to be completed?
Have the following endpoints working for searching recipes by category
* `GET api/v1/recipes`
* `GET api/v1/users/recipes`
#### How should this be manually tested?
After cloning the repo, cd into it
Run `npm start`
* Use Postman to test the endpoints above with this header
*key*: Content-Type *value*: apllication/json
* To test authentication, get TOKEN from `signin` endpoint and add to header
*key*: x-access-token *value*: JWT TOKEN
#### What are the relevant pivotal tracker stories?
#150878383