### PR TITLE
#151169355 Implement delete favorite

### DIFF
--- a/server/controllers/favorite.js
+++ b/server/controllers/favorite.js
@@ -53,6 +53,29 @@ const getUserFavorites = (req, res) => {
 };
 
 /**
+ * @description controller function to delete a user favorite recipe
+ * @param {object} req http request object to server
+ * @param {object} res http response object from server
+ * @returns {object} status message
+ */
+const deleteFavorite = (req, res) => {
+  // Use token generated to validate user identity
+  const userId = req.decoded.user.id,
+    recipeId = req.params.recipeId;
+  return Favorite
+  // Query the database to fetch all favorites unique to user's id
+  // Otherwise return all user's favorite recipe
+    .findOne({ where: { userId, recipeId } })
+    .then(favorite =>
+      favorite.destroy().then(() => res.status(200).send({
+        status: 'success',
+        message: 'Recipe successfully removed from favorites'
+      })))
+  // Catch error if any occurs
+    .catch(error => res.status(400).send(error));
+};
+
+/**
  * @description controller function for categorizing recipes
  * that have been added to a user's favorite recipe list
  * Note that this category is distinct from the global recipes category
@@ -85,4 +108,4 @@ const addRecipeCategory = (req, res) => Favorite
   })
   .catch(error => res.status(400).send(error));
 
-export { addFavorite, getUserFavorites, addRecipeCategory };
+export { addFavorite, getUserFavorites, addRecipeCategory, deleteFavorite };

--- a/server/routes/favorite.js
+++ b/server/routes/favorite.js
@@ -3,12 +3,13 @@ import auth from '../middlewares/auth';
 import validate from '../middlewares/validateParams';
 import { validUser } from '../middlewares/userValidation';
 import { validRecipe, favoriteExists, isValidFavorite } from '../middlewares/favoriteValidation';
-import { addFavorite, getUserFavorites, addRecipeCategory } from '../controllers/favorite';
+import { addFavorite, getUserFavorites, deleteFavorite, addRecipeCategory } from '../controllers/favorite';
 
 const router = express.Router();
 
 router.post('/api/v1/users/:recipeId/favorites', auth, validate, validUser, validRecipe, favoriteExists, addFavorite);
 router.put('/api/v1/users/:recipeId/favorites', auth, validate, validUser, validRecipe, isValidFavorite, addRecipeCategory);
+router.delete('/api/v1/users/:recipeId/favorites', auth, validate, validUser, validRecipe, isValidFavorite, deleteFavorite);
 router.get('/api/v1/users/recipes/favorites', auth, validUser, getUserFavorites);
 
 export default router;

--- a/server/test/yfavoriteTest.js
+++ b/server/test/yfavoriteTest.js
@@ -66,6 +66,40 @@ describe('Favorite a recipe', () => {
         done();
       });
   });
+  it('allows logged in user delete recipe he/she has favorited', (done) => {
+    server
+      .delete('/api/v1/users/2/favorites')
+      .set('Connection', 'keep alive')
+      .set('Accept', 'application/json')
+      .set('x-access-token', userData[1])
+      .set('Content-Type', 'application/json')
+      .type('form')
+      .send(favorite[1])
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.status).to.equal('success');
+        expect(res.body.message).to.be.equal('Recipe successfully removed from favorites');
+        if (err) return done(err);
+        done();
+      });
+  });
+  it('allows logged in user add recipe to favorite and category', (done) => {
+    server
+      .post('/api/v1/users/2/favorites')
+      .set('Connection', 'keep alive')
+      .set('Accept', 'application/json')
+      .set('x-access-token', userData[1])
+      .set('Content-Type', 'application/json')
+      .type('form')
+      .send(favorite[1])
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(201);
+        expect(res.body.status).to.equal('success');
+        expect(res.body.message).to.be.equal('Recipe successfully added to favorites');
+        if (err) return done(err);
+        done();
+      });
+  });
   it('does not allow user add same favorite more than once', (done) => {
     server
       .post('/api/v1/users/2/favorites')


### PR DESCRIPTION
#### What does this PR do?
Have delete on favorite resource endpoint
#### Description of Task to be completed?
Enable user to be able to delete a recipe from his/her favorite list if already added
Have the endpoint 'DELETE /api/v1/users/<recipeId>/favorites`
#### How should this be manually tested?
After cloning the repo, cd into it, run  `npm install` and then `npm start`
* Test the API route above using postman
* Obtain token authorization from `GET  ap1/v1/users/signin` or `GET  ap1/v1/users/signup`
* Set token in header with key `x-access-token`
#### What are the relevant pivotal tracker stories?
#151169355 #151169341
#### Screenshots
![image](https://user-images.githubusercontent.com/26303683/30543943-bef39b50-9c7c-11e7-9bd4-15192585c145.png)
